### PR TITLE
Fix link to streaming-iterables

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,5 +38,5 @@ Useful modules for working with async iterables:
 * [`pull-stream-to-async-iterator`](https://github.com/alanshaw/pull-stream-to-async-iterator) - Convert a pull stream to an async iterator
 * [`recoverable-iterator`](https://github.com/alanshaw/recoverable-iterator) - If an iterator errors, restart and continue
 * [`stream-to-it`](https://github.com/alanshaw/stream-to-it) - Convert Node.js streams to streaming iterables
-* [`streaming-iterables`](https://github.com/bustle/streaming-iterables) - A Swiss army knife for async iterables
+* [`streaming-iterables`](https://github.com/reconbot/streaming-iterables) - A Swiss army knife for async iterables
 * [`iter-tools`](https://github.com/iter-tools/iter-tools) - The iterable toolbox


### PR DESCRIPTION
The old repo is unmaintained. The [NPM package](https://www.npmjs.com/package/streaming-iterables) points to the new repo.